### PR TITLE
feat: Add back support for big-endian targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,31 @@ jobs:
       - run: cargo test --all-features
         if: matrix.rust == 'nightly'
 
+  test-be:
+    name: Test Big-Endian
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [mips-unknown-linux-gnu, mips64-unknown-linux-gnuabi64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Enable type layout randomization
+        run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo build -Zbuild-std
+      - run: cargo test -Zbuild-std
+      - run: cargo build --no-default-features -Zbuild-std
+      - run: cargo test --no-default-features -Zbuild-std
+
   miri:
     name: miri ${{ matrix.flags }}
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ smallvec = { version = "1.0", default-features = false, features = [
     "union",
 ] }
 ruint = { version = "1.15.0", default-features = false, features = ["alloc"] }
+cfg-if = "1.0"
 
 # serde
 serde = { version = "1.0", default-features = false, optional = true, features = [

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use core::{
     cmp::{self, Ordering},
     fmt,
@@ -131,8 +132,8 @@ impl Ord for Nibbles {
 
         // Slice to the loop iteration range to enable bound check
         // elimination in the compiler
-        let lhs = &self.nibbles.as_le_slice()[U256::BYTES - l..];
-        let rhs = &other.nibbles.as_le_slice()[U256::BYTES - l..];
+        let lhs = &self.nibbles.as_le_bytes()[U256::BYTES - l..];
+        let rhs = &other.nibbles.as_le_bytes()[U256::BYTES - l..];
 
         for i in (0..l).rev() {
             match lhs[i].cmp(&rhs[i]) {
@@ -335,12 +336,12 @@ impl Nibbles {
         let length = data.len() * 2;
         debug_assert!(length <= NIBBLES);
 
-        let mut nibbles = U256::ZERO;
+        let mut nibbles = [0u8; 32];
 
         // Source pointer is at the beginning
         let mut src = data.as_ptr().cast::<u8>();
         // Move destination pointer to the end of the little endian slice
-        let mut dst = nibbles.as_le_slice_mut().as_mut_ptr().add(U256::BYTES);
+        let mut dst = nibbles.as_mut_ptr().add(U256::BYTES);
         // On each iteration, decrement the destination pointer by one, set the destination
         // byte, and increment the source pointer by one
         for _ in 0..data.len() {
@@ -349,7 +350,7 @@ impl Nibbles {
             src = src.add(1);
         }
 
-        Self { length, nibbles }
+        Self { length, nibbles: U256::from_le_bytes(nibbles) }
     }
 
     /// Packs the nibbles into the given slice.
@@ -494,7 +495,7 @@ impl Nibbles {
     pub fn get_byte_unchecked(&self, i: usize) -> u8 {
         self.assert_index(i);
         if i % 2 == 0 {
-            self.nibbles.as_le_slice()[U256::BYTES - i / 2 - 1]
+            self.nibbles.as_le_bytes()[U256::BYTES - i / 2 - 1]
         } else {
             self.get_unchecked(i) << 4 | self.get_unchecked(i + 1)
         }
@@ -551,9 +552,9 @@ impl Nibbles {
 
         // Fast path for even-even and odd-odd sequences
         if self.len() % 2 == other.len() % 2 {
-            return self.nibbles.as_le_slice()
+            return self.nibbles.as_le_bytes()
                 [(NIBBLES - self.len()) / 2..(NIBBLES - self.len() + other.len()) / 2]
-                == other.nibbles.as_le_slice()[(NIBBLES - other.len()) / 2..];
+                == other.nibbles.as_le_bytes()[(NIBBLES - other.len()) / 2..];
         }
 
         let mut i = 0;
@@ -586,7 +587,7 @@ impl Nibbles {
     #[track_caller]
     pub fn get_unchecked(&self, i: usize) -> u8 {
         self.assert_index(i);
-        let byte = self.nibbles.as_le_slice()[U256::BYTES - i / 2 - 1];
+        let byte = self.nibbles.as_le_bytes()[U256::BYTES - i / 2 - 1];
         if i % 2 == 0 {
             byte >> 4
         } else {
@@ -615,12 +616,28 @@ impl Nibbles {
     #[inline]
     pub unsafe fn set_at_unchecked(&mut self, i: usize, value: u8) {
         let byte_index = U256::BYTES - i / 2 - 1;
+
         // SAFETY: index checked above
-        let byte = unsafe { &mut self.nibbles.as_le_slice_mut()[byte_index] };
+        cfg_if! {
+            if #[cfg(target_endian = "little")] {
+                let byte = unsafe { &mut self.nibbles.as_le_slice_mut()[byte_index] };
+            } else {
+                // Big-endian targets must first copy the nibbles to a little-endian slice.
+                let mut le_copy = self.nibbles.as_le_bytes().into_owned();
+                let byte = &mut le_copy[byte_index];
+            }
+        }
+
         if i % 2 == 0 {
             *byte = *byte & 0x0f | value << 4;
         } else {
             *byte = *byte & 0xf0 | value;
+        }
+
+        // For big-endian targets, replace the underlying U256 with the copied little-endian slice.
+        #[cfg(target_endian = "big")]
+        {
+            self.nibbles = U256::from_le_slice(&le_copy);
         }
     }
 
@@ -945,7 +962,7 @@ unsafe fn pack_to_unchecked(nibbles: &Nibbles, out: &mut [MaybeUninit<u8>]) {
     let byte_len = nibbles.len().div_ceil(2);
     debug_assert!(out.len() >= byte_len);
     // Move source pointer to the end of the little endian slice
-    let mut src = nibbles.nibbles.as_le_slice().as_ptr().add(U256::BYTES);
+    let mut src = nibbles.nibbles.as_le_bytes().as_ptr().add(U256::BYTES);
     // Destination pointer is at the beginning of the output slice
     let mut dst = out.as_mut_ptr().cast::<u8>();
     // On each iteration, decrement the source pointer by one, set the destination byte, and


### PR DESCRIPTION
## Overview

Adds back support for big-endian targets.

Test PR to run CI with the big-endian `mips64-unknown-linux-gnuabi64` target.